### PR TITLE
fix for markupsafe

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ confluent-kafka==1.7.0
 fastavro==1.4.7
 avro-to-python==0.3.2
 requests==2.26.0
+markupsafe==2.0.1


### PR DESCRIPTION
Latest version of MarkupSafe has issues and docker won't build, using 2.0.1 fixes (see example of reported issues that have rolled in since your last update: https://github.com/aws/aws-sam-cli/issues/3661)